### PR TITLE
Migrate to make_entity_preference() with backward compatibility

### DIFF
--- a/components/total_count/total_count.cpp
+++ b/components/total_count/total_count.cpp
@@ -1,5 +1,6 @@
 #include "total_count.h"
 #include "esphome/core/log.h"
+#include "esphome/core/version.h"
 
 namespace esphome {
 namespace total_count {
@@ -10,7 +11,11 @@ void TotalCount::setup() {
   uint32_t initial_value = this->initial_value_;
 
   if (this->restore_ && this->total_count_sensor_ != nullptr) {
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 2, 0)
+    this->pref_ = this->total_count_sensor_->make_entity_preference<float>();
+#else
     this->pref_ = global_preferences->make_preference<float>(this->total_count_sensor_->get_object_id_hash());
+#endif
     this->pref_.load(&initial_value);
   }
   this->publish_state_and_save(initial_value);


### PR DESCRIPTION
Replace deprecated get_object_id_hash() API with make_entity_preference<T>() when available (ESPHome >= 2026.2.0), while maintaining backward compatibility with older versions through conditional compilation.

The new API (PR esphome/esphome#13505) encapsulates preference creation and enables automatic preference migration when the hash algorithm is updated to fix collisions (see esphome/backlog#85).

Key changes:
- Use make_entity_preference<T>() on ESPHome >= 2026.2.0
- Fall back to get_object_id_hash() on older versions
- No breaking changes, no data loss for single-device setups
- Automatic migration to new API when users upgrade ESPHome