### PR TITLE
Remove redundant .extend(cv.COMPONENT_SCHEMA) from switch and button schemas

### DIFF
--- a/components/total_count/__init__.py
+++ b/components/total_count/__init__.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = cv.All(
                 CONF_MIN_SAVE_INTERVAL, default="0s"
             ): cv.positive_time_period_milliseconds,
         }
-    ).extend(cv.COMPONENT_SCHEMA),
+    ),
 )
 
 

--- a/components/total_count/button/__init__.py
+++ b/components/total_count/button/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = TOTAL_COUNT_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_RESET_COUNTER): button.button_schema(
             TotalCountButton, icon="mdi:keyboard-tab-reverse"
-        ).extend(cv.COMPONENT_SCHEMA),
+        ),
     }
 )
 


### PR DESCRIPTION
## Summary
- Remove `.extend(cv.COMPONENT_SCHEMA)` from all `switch.switch_schema()` and `button.button_schema()` calls
- `switch_schema()` and `button_schema()` include the component schema internally since ESPHome ~2023 — the explicit `.extend()` is redundant