### PR TITLE
Use new_* API instead of deprecated register_* functions

### DIFF
--- a/components/total_count/button/__init__.py
+++ b/components/total_count/button/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from .. import CONF_TOTAL_COUNT_ID, TOTAL_COUNT_COMPONENT_SCHEMA, total_count_ns
 
@@ -29,7 +28,6 @@ async def to_code(config):
     for key in [CONF_RESET_COUNTER]:
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
+            var = await button.new_button(conf)
             await cg.register_component(var, conf)
-            await button.register_button(var, conf)
             cg.add(var.set_parent(hub))

--- a/components/total_count/number/__init__.py
+++ b/components/total_count/number/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_MODE,
@@ -53,14 +52,12 @@ async def to_code(config):
     for key in [CONF_TOTAL_COUNT]:
         if key in config:
             conf = config[key]
-            var = cg.new_Pvariable(conf[CONF_ID])
-            await cg.register_component(var, conf)
-            await number.register_number(
-                var,
+            var = await number.new_number(
                 conf,
                 min_value=conf[CONF_MIN_VALUE],
                 max_value=conf[CONF_MAX_VALUE],
                 step=conf[CONF_STEP],
             )
+            await cg.register_component(var, conf)
             cg.add(getattr(hub, f"set_{key}_number")(var))
             cg.add(var.set_parent(hub))


### PR DESCRIPTION
## Summary

- Replace deprecated `register_button` and `register_number` calls with the new `new_button` and `new_number` API
- Remove now-unnecessary `CONF_ID` imports and `cg.new_Pvariable` calls
- Align with upstream migration as done in [syssi/esphome-jk-bms#912](https://github.com/syssi/esphome-jk-bms/pull/912)