### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/esp32-example-advanced.yaml
+++ b/esp32-example-advanced.yaml
@@ -41,13 +41,13 @@ total_count:
 binary_sensor:
   - platform: gpio
     pin: GPIO32
-    name: "${name} light barrier 0"
+    name: "light barrier 0"
     id: barrier0
     filters:
       - delayed_on: 20ms
   - platform: gpio
     pin: GPIO33
-    name: "${name} light barrier 1"
+    name: "light barrier 1"
     id: barrier1
     filters:
       - delayed_on: 20ms
@@ -56,28 +56,28 @@ sensor:
   - platform: total_count
     total_count_id: total_count0
     total_count:
-      name: "${name} total count 0"
+      name: "total count 0"
   - platform: total_count
     total_count_id: total_count1
     total_count:
-      name: "${name} total count 1"
+      name: "total count 1"
 
 number:
   - platform: total_count
     total_count_id: total_count0
     total_count:
-      name: "${name} total count 0"
+      name: "total count 0"
   - platform: total_count
     total_count_id: total_count1
     total_count:
-      name: "${name} total count 1"
+      name: "total count 1"
 
 button:
   - platform: total_count
     total_count_id: total_count0
     reset_counter:
-      name: "${name} reset counter 0"
+      name: "reset counter 0"
   - platform: total_count
     total_count_id: total_count1
     reset_counter:
-      name: "${name} reset counter 1"
+      name: "reset counter 1"

--- a/esp32-example-advanced.yaml
+++ b/esp32-example-advanced.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: esp-wrover-kit

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -34,7 +34,7 @@ total_count:
 binary_sensor:
   - platform: gpio
     pin: GPIO32
-    name: "${name} light barrier"
+    name: "light barrier"
     id: barrier
     filters:
       - delayed_on: 20ms
@@ -42,14 +42,14 @@ binary_sensor:
 sensor:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 number:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 button:
   - platform: total_count
     reset_counter:
-      name: "${name} reset counter"
+      name: "reset counter"

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: esp-wrover-kit

--- a/esp8266-example-advanced.yaml
+++ b/esp8266-example-advanced.yaml
@@ -41,13 +41,13 @@ total_count:
 binary_sensor:
   - platform: gpio
     pin: GPIO4
-    name: "${name} light barrier 0"
+    name: "light barrier 0"
     id: barrier0
     filters:
       - delayed_on: 20ms
   - platform: gpio
     pin: GPIO5
-    name: "${name} light barrier 1"
+    name: "light barrier 1"
     id: barrier1
     filters:
       - delayed_on: 20ms
@@ -56,28 +56,28 @@ sensor:
   - platform: total_count
     total_count_id: total_count0
     total_count:
-      name: "${name} total count 0"
+      name: "total count 0"
   - platform: total_count
     total_count_id: total_count1
     total_count:
-      name: "${name} total count 1"
+      name: "total count 1"
 
 number:
   - platform: total_count
     total_count_id: total_count0
     total_count:
-      name: "${name} total count 0"
+      name: "total count 0"
   - platform: total_count
     total_count_id: total_count1
     total_count:
-      name: "${name} total count 1"
+      name: "total count 1"
 
 button:
   - platform: total_count
     total_count_id: total_count0
     reset_counter:
-      name: "${name} reset counter 0"
+      name: "reset counter 0"
   - platform: total_count
     total_count_id: total_count1
     reset_counter:
-      name: "${name} reset counter 1"
+      name: "reset counter 1"

--- a/esp8266-example-advanced.yaml
+++ b/esp8266-example-advanced.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -34,7 +34,7 @@ total_count:
 binary_sensor:
   - platform: gpio
     pin: GPIO4
-    name: "${name} light barrier"
+    name: "light barrier"
     id: barrier
     filters:
       - delayed_on: 20ms
@@ -42,14 +42,14 @@ binary_sensor:
 sensor:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 number:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 button:
   - platform: total_count
     reset_counter:
-      name: "${name} reset counter"
+      name: "reset counter"

--- a/esp8266-example.yaml
+++ b/esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -5,6 +5,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
 
 esp32:

--- a/tests/esp32c6-compatibility-test.yaml
+++ b/tests/esp32c6-compatibility-test.yaml
@@ -40,7 +40,7 @@ total_count:
 binary_sensor:
   - platform: gpio
     pin: GPIO16
-    name: "${name} light barrier"
+    name: "light barrier"
     id: barrier
     filters:
       - delayed_on: 20ms
@@ -48,14 +48,14 @@ binary_sensor:
 sensor:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 number:
   - platform: total_count
     total_count:
-      name: "${name} total count"
+      name: "total count"
 
 button:
   - platform: total_count
     reset_counter:
-      name: "${name} reset counter"
+      name: "reset counter"


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.