### PR TITLE
Use ESP-IDF framework

### DIFF
--- a/esp32-example-advanced.yaml
+++ b/esp32-example-advanced.yaml
@@ -8,6 +8,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}

--- a/esp32-example.yaml
+++ b/esp32-example.yaml
@@ -8,6 +8,8 @@ esphome:
 
 esp32:
   board: esp-wrover-kit
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
## Summary
- Switch from Arduino to ESP-IDF framework per ESPHome 2026.1.0 deprecation warning