### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/total_count/button/total_count_button.cpp
+++ b/components/total_count/button/total_count_button.cpp
@@ -2,13 +2,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 static const char *const TAG = "total_count.button";
 
 void TotalCountButton::dump_config() { LOG_BUTTON("", "TotalCount Button", this); }
 void TotalCountButton::press_action() { this->parent_->reset_counter(); }
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count

--- a/components/total_count/button/total_count_button.h
+++ b/components/total_count/button/total_count_button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 class TotalCount;
 class TotalCountButton : public button::Button, public Component {
@@ -20,5 +19,4 @@ class TotalCountButton : public button::Button, public Component {
   TotalCount *parent_;
 };
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count

--- a/components/total_count/number/total_count_number.cpp
+++ b/components/total_count/number/total_count_number.cpp
@@ -1,13 +1,11 @@
 #include "total_count_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 static const char *const TAG = "total_count.number";
 
 void TotalCountNumber::control(float value) { this->parent_->set_value(value); }
 void TotalCountNumber::dump_config() { LOG_NUMBER(TAG, "TotalCount Number", this); }
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count

--- a/components/total_count/number/total_count_number.h
+++ b/components/total_count/number/total_count_number.h
@@ -5,8 +5,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 class TotalCount;
 
@@ -21,5 +20,4 @@ class TotalCountNumber : public number::Number, public Component {
   TotalCount *parent_;
 };
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count

--- a/components/total_count/total_count.cpp
+++ b/components/total_count/total_count.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 static const char *const TAG = "total_count";
 
@@ -73,5 +72,4 @@ void TotalCount::publish_state_(number::Number *sensor, float value) {
   sensor->publish_state(value);
 }
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count

--- a/components/total_count/total_count.h
+++ b/components/total_count/total_count.h
@@ -7,8 +7,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace total_count {
+namespace esphome::total_count {
 
 class TotalCount : public Component {
  public:
@@ -46,5 +45,4 @@ class TotalCount : public Component {
   bool restore_;
 };
 
-}  // namespace total_count
-}  // namespace esphome
+}  // namespace esphome::total_count


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.