### PR TITLE
Add C++ tests

### DIFF
--- a/tests/components/total_count/common.h
+++ b/tests/components/total_count/common.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "esphome/components/total_count/total_count.h"
+
+namespace esphome::total_count::testing {
+
+class TestableTotalCount : public TotalCount {
+ public:
+  using TotalCount::process_new_state_;
+};
+
+}  // namespace esphome::total_count::testing

--- a/tests/components/total_count/test.host.yaml
+++ b/tests/components/total_count/test.host.yaml
@@ -1,0 +1,9 @@
+binary_sensor:
+  - platform: template
+    id: trigger_sensor
+
+total_count:
+  - binary_sensor_id: trigger_sensor
+    restore: false
+    initial_value: 0
+    step: 1

--- a/tests/components/total_count/total_count_test.cpp
+++ b/tests/components/total_count/total_count_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include "esphome/components/sensor/sensor.h"
+#include "common.h"
+
+namespace esphome::total_count::testing {
+
+class TotalCountTest : public ::testing::Test {
+ protected:
+  TestableTotalCount counter_;
+  sensor::Sensor total_count_sensor_;
+
+  void SetUp() override {
+    counter_.set_restore(false);
+    counter_.set_initial_value(0);
+    counter_.set_step(1);
+    counter_.set_total_count_sensor(&total_count_sensor_);
+  }
+};
+
+TEST_F(TotalCountTest, SetValuePublishes) {
+  counter_.set_value(5.0f);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 5.0f);
+}
+
+TEST_F(TotalCountTest, PublishStateAndSave) {
+  counter_.publish_state_and_save(42);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 42.0f);
+}
+
+TEST_F(TotalCountTest, ResetCounterToInitialValue) {
+  counter_.set_value(99.0f);
+  counter_.reset_counter();
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 0.0f);
+}
+
+TEST_F(TotalCountTest, ResetCounterToCustomInitialValue) {
+  counter_.set_initial_value(10);
+  counter_.set_value(99.0f);
+  counter_.reset_counter();
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 10.0f);
+}
+
+TEST_F(TotalCountTest, ProcessNewStateIncrements) {
+  counter_.publish_state_and_save(3);
+  counter_.process_new_state_(true);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 4.0f);
+}
+
+TEST_F(TotalCountTest, ProcessNewStateFalseNoIncrement) {
+  counter_.publish_state_and_save(3);
+  counter_.process_new_state_(false);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 3.0f);
+}
+
+TEST_F(TotalCountTest, StepTwo) {
+  counter_.set_step(2);
+  counter_.publish_state_and_save(0);
+  counter_.process_new_state_(true);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 2.0f);
+}
+
+TEST_F(TotalCountTest, MultipleIncrements) {
+  counter_.publish_state_and_save(0);
+  counter_.process_new_state_(true);
+  counter_.process_new_state_(true);
+  counter_.process_new_state_(true);
+  EXPECT_FLOAT_EQ(total_count_sensor_.state, 3.0f);
+}
+
+TEST_F(TotalCountTest, NullSensorSafe) {
+  TestableTotalCount bare;
+  bare.set_restore(false);
+  bare.set_initial_value(0);
+  bare.set_step(1);
+  EXPECT_NO_FATAL_FAILURE(bare.publish_state_and_save(5));
+}
+
+}  // namespace esphome::total_count::testing


### PR DESCRIPTION
## Summary

- Adds `tests/components/total_count/` with host build YAML, testable subclass, and 9 test cases
- Tests cover set_value, publish_state_and_save, reset_counter (default and custom initial_value), process_new_state_ incrementing with step=1 and step=2, and null-sensor guard
- `restore: false` used throughout to avoid ESPPreference interaction in host tests
