### PR TITLE
Introduce SENSOR_DEFS and extend schema tests

### DIFF
--- a/components/total_count/sensor.py
+++ b/components/total_count/sensor.py
@@ -19,7 +19,10 @@ SENSOR_DEFS = {
 }
 
 CONFIG_SCHEMA = TOTAL_COUNT_COMPONENT_SCHEMA.extend(
-    {cv.Required(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
+    {
+        cv.Required(key): sensor.sensor_schema(**kwargs)
+        for key, kwargs in SENSOR_DEFS.items()
+    }
 )
 
 

--- a/components/total_count/sensor.py
+++ b/components/total_count/sensor.py
@@ -9,22 +9,23 @@ CODEOWNERS = ["@syssi"]
 
 CONF_TOTAL_COUNT = "total_count"
 
+SENSOR_DEFS = {
+    CONF_TOTAL_COUNT: {
+        "unit_of_measurement": UNIT_EMPTY,
+        "icon": "mdi:counter",
+        "accuracy_decimals": 0,
+        "state_class": STATE_CLASS_TOTAL_INCREASING,
+    },
+}
+
 CONFIG_SCHEMA = TOTAL_COUNT_COMPONENT_SCHEMA.extend(
-    {
-        cv.Required(CONF_TOTAL_COUNT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_EMPTY,
-            icon="mdi:counter",
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-    }
+    {cv.Required(key): sensor.sensor_schema(**kwargs) for key, kwargs in SENSOR_DEFS.items()}
 )
 
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_TOTAL_COUNT_ID])
-    for key in [CONF_TOTAL_COUNT]:
+    for key in SENSOR_DEFS:
         if key in config:
-            conf = config[key]
-            sens = await sensor.new_sensor(conf)
+            sens = await sensor.new_sensor(config[key])
             cg.add(getattr(hub, f"set_{key}_sensor")(sens))

--- a/tests/test_component_schemas.py
+++ b/tests/test_component_schemas.py
@@ -15,6 +15,14 @@ class TestHubConstants:
         assert hub.CONF_BINARY_SENSOR_ID == "binary_sensor_id"
 
 
-class TestSensorConstants:
-    def test_conf_total_count_defined(self):
-        assert sensor.CONF_TOTAL_COUNT == "total_count"
+class TestSensorDefs:
+    def test_sensor_defs_completeness(self):
+        assert sensor.CONF_TOTAL_COUNT in sensor.SENSOR_DEFS
+        assert len(sensor.SENSOR_DEFS) == 1
+
+    def test_sensor_defs_keys_match_schema(self):
+        assert set(sensor.SENSOR_DEFS.keys()) == {sensor.CONF_TOTAL_COUNT}
+
+    def test_sensor_keys_are_strings(self):
+        for key in sensor.SENSOR_DEFS:
+            assert isinstance(key, str)


### PR DESCRIPTION
## Summary

- Replaces the inline `sensor.sensor_schema()` call in `total_count/sensor.py` with a `SENSOR_DEFS` dict
- Since both schema registration and code generation iterate over the same dict, it is structurally impossible to declare a sensor without registering it
- Expands `tests/test_component_schemas.py` with `TestSensorDefs` covering count, key presence, and string-type assertions

## Test plan

- [ ] `pytest tests/test_component_schemas.py` passes
- [ ] `total_count` sensor schema unchanged from user perspective (`total_count` still required)